### PR TITLE
feat: Add Android APK build to workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,3 +46,33 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build for Cordova
+        run: vite build --outDir www --base /android_asset/www/
+
+      - name: Setup Cordova
+        uses: buluma/setup-cordova@v0.0.3
+        with:
+          exec: |
+            cordova platform add android
+            cordova build android --release
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release.apk
+          path: platforms/android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
This commit adds a new job to the `gh-pages.yml` workflow to build an Android APK.

The new `build-android` job uses the `buluma/setup-cordova` action to simplify the Cordova build process. It performs the following steps:
- Checks out the repository
- Sets up Node.js
- Installs npm dependencies
- Builds the web assets for Cordova
- Builds the Android release APK
- Uploads the generated APK as a build artifact