### PR TITLE
feat: Add new deployment workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,114 @@
+# .github/workflows/deploy.yml
+name: Build & Deploy (GitHub Pages + Cordova)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build for GitHub Pages
+        env:
+          BUILD_TARGET: web
+        run: npm run build -- --mode production
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: web
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+
+  cordova:
+    needs: web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Cordova CLI
+        run: npm i -g cordova
+
+      - name: Create Cordova project (if missing)
+        run: |
+          if [ ! -f cordova/config.xml ]; then
+            cordova create cordova com.easierbycode.evilinvaders "Evil Invaders"
+            cordova telemetry off
+          fi
+
+      - name: Build web assets for Cordova
+        env:
+          BUILD_TARGET: cordova
+        run: npm run build -- --mode production
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android packages
+        run: |
+          sdkmanager --install "platform-tools" "platforms;android-34" "build-tools;34.0.0" || true
+          yes | sdkmanager --licenses
+
+      - name: Add Android platform
+        working-directory: cordova
+        run: cordova platform add android
+
+      # 👉 Build APK only (no AAB)
+      - name: Build Cordova Android (release APK)
+        working-directory: cordova
+        run: cordova build android --release --packageType=apk
+
+      - name: Verify asset-pack presence
+        run: |
+          echo "dist:"
+          ls -la dist/assets | head -n 50 || true
+          echo "cordova/www:"
+          ls -la cordova/www/assets | head -n 50 || true
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: evil-invaders-android-apk
+          path: |
+            cordova/platforms/android/app/build/outputs/apk/**/*.apk


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow at `.github/workflows/deploy.yaml`.

This workflow builds and deploys the application to both GitHub Pages and as an Android APK. It is based on the workflow from `easierbycode/evil-invaders-phaser4`.

The workflow includes jobs for:
- Building the web application for GitHub Pages.
- Deploying to GitHub Pages.
- Building the Android release APK using Cordova.
- Uploading the APK as a build artifact.