### PR TITLE
fix: Use Java 8 for Cordova build

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,11 +75,11 @@ jobs:
           BUILD_TARGET: cordova
         run: npm run build -- --mode production
 
-      - name: Setup Java 17
+      - name: Setup Java 8
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "8"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3


### PR DESCRIPTION
This commit updates the `deploy.yaml` workflow to use Java 8 for the Cordova build process.

The version of `cordova-android` used in the project requires JDK 8, but the workflow was configured to use Java 17, which caused a build failure.

This change downgrades the Java version in the workflow to 8, which aligns with the requirements of the Cordova build tools and resolves the build error.