### PR TITLE
fix: Resolve conflicting Java version requirements

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,11 +75,11 @@ jobs:
           BUILD_TARGET: cordova
         run: npm run build -- --mode production
 
-      - name: Setup Java 8
+      - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "8"
+          java-version: "17"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "assets": "^3.0.1",
     "cordova": "^10.0.0",
-    "cordova-android": "^8.1.0",
+    "cordova-android": "^11.0.0",
     "phaser": "3.90.0",
     "phaser3_gui_inspector": "^1.2.1"
   },


### PR DESCRIPTION
This commit resolves a conflict between the Java version required by the Android SDK tools and the version required by `cordova-android`.

The `cordova-android` dependency has been upgraded to `^11.0.0`, which is compatible with modern Java versions. The deployment workflow has been updated to use Java 17, which is required by the Android SDK tools.

This change aligns the dependencies and tools, resolving the build failure.