### PR TITLE
ci: only deploy to GitHub Pages from the default branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,9 @@ jobs:
 
   deploy:
     needs: web
+    # The github-pages environment only permits deploys from the default branch,
+    # so skip this job elsewhere (feature-branch pushes still build via `web`).
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Problem

The `github-pages` environment has a protection rule that only allows the default branch (`master`) to deploy. Because the `deploy` job had no branch guard, every feature-branch push attempted a Pages deploy and failed in ~2s with:

> Branch "<name>" is not allowed to deploy to github-pages due to environment protection rules. The deployment was rejected or didn't satisfy other protection rules.

This produced a spurious red ❌ on the overall run even when the `web` build and `cordova` APK jobs passed.

## Fix

Gate the `deploy` job with `if: github.ref == 'refs/heads/master'` so it is **skipped** (not failed) on other branches. The `web` and `cordova` build jobs still run on every branch, preserving build validation on PRs.

## Verification

CI run on this branch is green with `deploy` **skipped**:

- `web` ✓
- `cordova` ✓
- `deploy` ⏭️ skipped

On `master`, `github.ref == 'refs/heads/master'` is satisfied, so Pages deploy runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)