### PR TITLE
fix(controls): make SNES ZR trigger Next Weapon

### DIFF
--- a/src/js/controls.ts
+++ b/src/js/controls.ts
@@ -114,6 +114,21 @@ export function actionsForButton(idx: number): ActionId[] {
 // (the menu drives its own navigation off the very same buttons).
 export const ControlsState = { open: false };
 
+// Some pads report non-standard button indices. The Switch-Online SNES pad
+// (id "SNES Controller …", 057e:2017) sends ZR as button 15 — which the W3C
+// standard layout calls "d-pad right" — instead of the standard R2 = 7, so its
+// trigger never matches the default Next-Weapon binding. For SNES pads we alias
+// the repurposed index back to the standard one the bindings use, so the trigger
+// works without remapping (and still follows R2 if the user rebinds it). Gated
+// to SNES pads in Player so a standard pad's real d-pad-right is unaffected.
+const SNES_BUTTON_ALIAS: Record<number, number> = {
+    15: 7, // ZR → R2 (Next Weapon)
+};
+
+export function aliasSnesButton(idx: number): number {
+    return SNES_BUTTON_ALIAS[idx] ?? idx;
+}
+
 // Analog triggers (L2/R2 = standard indices 6/7) default to a Phaser press
 // threshold of 1.0, so a 'down' event only fires on a *full* pull — and some
 // pads top out just under 1.0 and never fire. Lower those two buttons to 0.5 so

--- a/src/js/player.ts
+++ b/src/js/player.ts
@@ -7,7 +7,7 @@ import IonBullet from "./ion-bullet";
 import PacmanBullet from "./pacman-bullet";
 import { Bullet, Weapon } from './weapon-plugin';
 import { BULLET_KILL } from "./weapon-plugin/events";
-import { actionsForButton, ControlsState, lowerTriggerThresholds } from "./controls";
+import { actionsForButton, aliasSnesButton, ControlsState, lowerTriggerThresholds } from "./controls";
 
 
 export default class Player extends BaseEntity {
@@ -27,6 +27,9 @@ export default class Player extends BaseEntity {
     // (axes [2]/[3]) stays at 0,0 and can't aim. For those we aim with the face
     // buttons and auto-fire instead.
     private useFaceButtonAiming: boolean = false;
+    // SNES pads remap some buttons (ZR → b15); alias them back to standard
+    // indices before action dispatch so the default bindings apply. See controls.ts.
+    private isSnesPad: boolean = false;
 
     // Raw `buttons[]` indices for the four face buttons, used for aiming.
     // The Switch-Online SNES pad reports a NON-standard layout (mapping === '',
@@ -77,7 +80,8 @@ export default class Player extends BaseEntity {
         // Switch-Online SNES pad reports id "SNES Controller ..." with ~10 axes),
         // so detect them by id, with a fallback for true low-axis-count pads.
         const padId = ( this.gamepad.id || '' ).toLowerCase();
-        this.useFaceButtonAiming = /snes/.test( padId ) || this.gamepad.axes.length < 4;
+        this.isSnesPad = /snes/.test( padId );
+        this.useFaceButtonAiming = this.isSnesPad || this.gamepad.axes.length < 4;
 
         // Button → action dispatch is driven by the remappable bindings in
         // controls.ts (edited via the in-game Controls UI). Defaults: Dash on
@@ -87,7 +91,11 @@ export default class Player extends BaseEntity {
             // off these same buttons.
             if (ControlsState.open)  return;
 
-            for (const action of actionsForButton(idx)) {
+            // SNES pads report some buttons at non-standard indices (ZR → b15);
+            // map them back so the default bindings (R2 = 7, etc.) apply.
+            const button = this.isSnesPad ? aliasSnesButton(idx) : idx;
+
+            for (const action of actionsForButton(button)) {
                 switch (action) {
                     case 'dash':        this.barrierDash();   break;
                     case 'prevWeapon':  this.cycleWeapon(-1); break;


### PR DESCRIPTION
The Switch-Online SNES pad (057e:2017) reports ZR as button 15 — which the W3C standard layout calls "d-pad right" — not the standard R2 = 7, so the default Next Weapon binding never matched and ZR did nothing. Alias the repurposed index back to standard for SNES pads only (gated on the pad id), so ZR works without remapping and still follows R2 if the user rebinds it; a standard pad's real d-pad-right stays unaffected.